### PR TITLE
Shell escape cmd echo

### DIFF
--- a/models/travis_yml_script.rb
+++ b/models/travis_yml_script.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'shellwords'
 
 class TravisYmlScript
   def initialize(attrs = {})
@@ -91,7 +92,8 @@ __FOOTER__
   end
 
   def echo(cmd)
-    run("echo $ #{cmd}")
+    cmd_e = Shellwords.shellescape(cmd)
+    run("echo $ "+cmd_e)
   end
 
   def capture_result

--- a/travis-yml.pluginspec
+++ b/travis-yml.pluginspec
@@ -1,7 +1,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = "travis-yml"
   plugin.display_name = "Travis YML Plugin"
-  plugin.version = '0.1.0'
+  plugin.version = '0.1.1'
   plugin.description = 'Run Jenkins builds using .travis.yml in your project'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Travis+YML+Plugin'


### PR DESCRIPTION
travis commands containing a semicolon were triggering failures. I have added shellescape on the echo commands to prevent this. 
